### PR TITLE
Issue/7 Foreign characters not saving in wiki tables

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -26,3 +26,4 @@ This issue is:
 - PHP version:
 - OS:
 - Browser:
+- Application settings Language:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+ersion 0.2.7-alpha
+
+Bug fixes:
+
+* Update mysql wiki table encoding to utf8 to support foreign characters
+
 Version 0.2.6-alpha
 
 Improvements:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 plugin=Wiki
-version=0.2.6
+version=0.2.7
 all:
 	@ echo "Build archive for plugin ${plugin} version=${version}"
 	@ git archive HEAD --prefix=${plugin}/ --format=zip -o ${plugin}-${version}.zip

--- a/Plugin.php
+++ b/Plugin.php
@@ -76,7 +76,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '0.2.6';
+        return '0.2.7';
     }
 
     public function getPluginHomepage()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ version=0.2.6
 
 To run a new build type `make`. NOTE: this only zips files in the last commit in the branch you are on. If you haven't commited your changes these won't be included in the zip.
 
-After testing create a new tag in github or via cli. `git tag -a 0.2.6 -m "Translations Updates"` Then upload the new **Wiki-version.zip**. Then do a pull request on https://github.com/kanboard/website for the plugins.json to update the plugin url. The `version` & `download` attributes are important to be correct.
+After testing create a new tag in github or via cli. `git tag -a 0.2.6 -m "Translations Updates"`. Then `git push origin --tags` Then upload the new **Wiki-version.zip** produced from `make`. Then do a pull request on https://github.com/kanboard/website for the plugins.json to update the plugin url. The `version` & `download` attributes are important to be correct.
 
 ```json
 {

--- a/Schema/Mysql.php
+++ b/Schema/Mysql.php
@@ -7,12 +7,8 @@ use PDO;
 const VERSION = 7;
 
 function version_7(PDO $pdo){
-    // $pdo->exec("SET foreign_key_checks = 0;");
-    // double check if utf8 correct type for foreign letter support
     $pdo->exec("ALTER TABLE wikipage CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;");
     $pdo->exec("ALTER TABLE wikipage_editions CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;");
-    // $pdo->exec("SET foreign_key_checks = 1;");
-
 }
 
 function version_6(PDO $pdo){

--- a/Schema/Mysql.php
+++ b/Schema/Mysql.php
@@ -5,18 +5,17 @@ namespace Kanboard\Plugin\Wiki\Schema;
 use PDO;
 
 const VERSION = 7;
-function version_6(PDO $pdo){
-    // insert persistEditions into settings
-    $pdo->exec("SET foreign_key_checks = 0;");
+
+function version_7(PDO $pdo){
+    // $pdo->exec("SET foreign_key_checks = 0;");
     // double check if utf8 correct type for foreign letter support
     $pdo->exec("ALTER TABLE wikipage CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;");
     $pdo->exec("ALTER TABLE wikipage_editions CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;");
-    $pdo->exec("SET foreign_key_checks = 1;");
+    // $pdo->exec("SET foreign_key_checks = 1;");
 
 }
 
 function version_6(PDO $pdo){
-    // insert persistEditions into settings
     $pdo->exec("ALTER TABLE `wikipage` CHANGE COLUMN `order` `ordercolumn` int(11) NOT NULL;");
 }
 

--- a/Schema/Mysql.php
+++ b/Schema/Mysql.php
@@ -4,7 +4,16 @@ namespace Kanboard\Plugin\Wiki\Schema;
 
 use PDO;
 
-const VERSION = 6;
+const VERSION = 7;
+function version_6(PDO $pdo){
+    // insert persistEditions into settings
+    $pdo->exec("SET foreign_key_checks = 0;");
+    // double check if utf8 correct type for foreign letter support
+    $pdo->exec("ALTER TABLE wikipage CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;");
+    $pdo->exec("ALTER TABLE wikipage_editions CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;");
+    $pdo->exec("SET foreign_key_checks = 1;");
+
+}
 
 function version_6(PDO $pdo){
     // insert persistEditions into settings


### PR DESCRIPTION
### All Submissions:

* [x ] Have you updated the ChangeLog with your proposed changes?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you updated the getPluginVersion() in Plugin.php and Makefile version appropriately?

### New Feature Submissions:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?

### Description

Only affects mysql database users. Tested on postgres & sqlite. Not an issue.
Fixes #7 

Changes proposed in this pull request:

Bug fixes:

* Update mysql wiki table encoding to utf8 to support foreign characters
