### PR TITLE
Set edit mode to `true` when logged in to fix #56

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,10 @@ Improvements:
 
 * public wiki link to board
 
+Bug fixes:
+
+* Make pages editable when logged in. Fixes #56.
+
 Version 0.3.2
 Improvements:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -38,9 +38,9 @@ Improvements:
   * Added Thumbnail Support
   * Added Download Support
   * Added Removal Support
-  * Added Slideshow Support for images  
+  * Added Slideshow Support for images
 * Updated French translation
-  
+
 Version 0.2.8-alpha
 
 Improvements:
@@ -71,7 +71,7 @@ Improvements:
   * Updated translation for New wikipage (incorrectly was New wiki line)
   * Missing translation empty attributes added
   * Portuguese & Spanish updated
-  * 'Wiki' Translation commented out in most language. Was defaulting to budget. 
+  * 'Wiki' Translation commented out in most language. Was defaulting to budget.
 * Some linting fixes on readme files
 
 Version 0.2.5-alpha
@@ -163,7 +163,7 @@ New features:
 
 Improvements:
 
-* 
+*
 
 Bug fixes:
 

--- a/Controller/WikiController.php
+++ b/Controller/WikiController.php
@@ -31,7 +31,7 @@ class WikiController extends BaseController
 
 
         // echo json_encode($query->findAll());
-        // exit(); 
+        // exit();
         // $wikipages = $this->wiki->getWikipages($project['id']);
 
         $search = $this->request->getStringParam('search');
@@ -138,7 +138,6 @@ class WikiController extends BaseController
 
     public function detail_readonly() {
         $token = $this->request->getStringParam('token');
-        
         $project = $this->projectModel->getByToken($token);
 
         if (empty($project)) {
@@ -182,7 +181,6 @@ class WikiController extends BaseController
     public function detail()
     {
         $project = $this->getProject();
-        
         $wiki_id = $this->request->getIntegerParam('wiki_id');
 
         $wikipages = $this->wiki->getWikipages($project['id']);
@@ -420,5 +418,4 @@ class WikiController extends BaseController
 
         $this->response->redirect($this->helper->url->to('WikiController', 'show', array('plugin' => 'wiki', 'project_id' => $project['id'])), true);
     }
-    
 }

--- a/Controller/WikiController.php
+++ b/Controller/WikiController.php
@@ -85,6 +85,8 @@ class WikiController extends BaseController
 
         $this->response->html($this->helper->layout->app('wiki:wiki/show', array(
             'project' => $project,
+            'no_layout' => false,
+            'not_editable' => false,
             'title' => $project['name'] .= " ". t('Wiki'),
             'wikipages' => $this->wiki->getWikipages($project['id']),
         ), 'wiki:wiki/sidebar'));
@@ -203,6 +205,8 @@ class WikiController extends BaseController
             'title' => t('Wikipage'),
             'wiki_id' => $wiki_id,
             'wiki' => $wikipage,
+            'no_layout' => false,
+            'not_editable' => false,
             'files' => $this->wikiFile->getAllDocuments($wiki_id),
             'images' => $this->wikiFile->getAllImages($wiki_id),
             // 'wikipage' => $this->wiki->getWikipage($wiki_id),


### PR DESCRIPTION
### All Submissions:

* [x] Have you updated the ChangeLog with your proposed changes?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* pr update to master branch
  * [ ] Have you updated the getPluginVersion() in Plugin.php and Makefile version appropriately?

### Description

Fixes #56

As `0.3.3` is not released yet I did not increment the version.

**Changes proposed in this pull request:**

So unfortunately I have no clue of PHP in general or Kanboard plugins, but I was affected by #56 and upon glancing into the code I came up with the following:

The variable `$not_editable` seems to be part of commit 695f148 which implemented a public mode for the wiki via settings this to `true`, but in the respective methods when viewing pages logged in the variable is not set to `false` (or maybe it should have been set by default, as I said I have no real idea of PHP).

Please also note that the same applies to the variable `$no_layout`, but that one causes no error and it seems to make no difference to negate it explicitly.
