### PR TITLE
Use relative paths for function js()

### DIFF
--- a/Helper/WikiHelper.php
+++ b/Helper/WikiHelper.php
@@ -31,15 +31,13 @@ class WikiHelper extends Base
     /**
      * Add a Javascript asset
      *
-     * @param  string $filename Filename
+     * @param  string $filepath Filepath
      * @param  bool   $async
      * @return string
      */
-    public function js($filename, $async = false)
+    public function js($filepath, $async = false)
     {
-        $dir = dirname(__DIR__,2);
-        $filepath = $dir.'/'.$filename;
-        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir()."plugins".$filename.'?'.filemtime($filepath).'"></script>';
+        return '<script '.($async ? 'async' : '').' defer type="text/javascript" src="'.$this->helper->url->dir().$filepath.'?'.filemtime($filepath).'"></script>';
     }
     /**
      * render wiki page html children recursively

--- a/Template/wiki/detail.php
+++ b/Template/wiki/detail.php
@@ -1,8 +1,8 @@
 <?php (isset($not_editable)) ?: $not_editable = false;
 ?>
 <?php if (!$not_editable): ?>
-    <?=$this->wikiHelper->js("/Wiki/Asset/vendor/jquery-sortable/jquery-sortable.js")?>
-    <?=$this->wikiHelper->js("/Wiki/Asset/Javascript/wiki.js")?>
+    <?=$this->wikiHelper->js("plugins/Wiki/Asset/vendor/jquery-sortable/jquery-sortable.js")?>
+    <?=$this->wikiHelper->js("plugins/Wiki/Asset/Javascript/wiki.js")?>
     <?= $this->projectHeader->render($project, 'TaskListController', 'show') ?>
 <?php endif ?>
 <div class="page-header">


### PR DESCRIPTION
### All Submissions:

* [ ] Have you updated the ChangeLog with your proposed changes?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* pr update to master branch
  * [ ] Have you updated the getPluginVersion() in Plugin.php and Makefile version appropriately?

### New Feature Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Description

We have a composer based installation of kanboard and your plugin Wiki. The plugins are stored inside vendor folder (because composer does it) and symlinked in /vendor/kanboard/kanboard/plugins/.

The class WikiHelper.php tries to generate an absolute path which doesn't work in such environments, because the plugin is stored in /var/www/app_kanboard/vendor/funktechno/kanboard-plugin-wiki and not /var/www/app_kanboard/vendor/funktechno/Wiki. See warning:

`Warning: filemtime(): stat failed for /var/www/app_kanboard/vendor/funktechno//Wiki/Asset/vendor/jquery-sortable/jquery-sortable.js in /var/www/app_kanboard/vendor/funktechno/kanboard-plugin-wiki/Helper/WikiHelper.php on line 42`

`Warning: filemtime(): stat failed for /var/www/app_kanboard/vendor/funktechno//Wiki/Asset/Javascript/wiki.js in /var/www/app_kanboard/vendor/funktechno/kanboard-plugin-wiki/Helper/WikiHelper.php on line 42`

You can fix this by adding another symlink from "Wiki" to "kanboard-plugin-wiki", but there is a better solution:

First, your code in https://github.com/funktechno/kanboard-plugin-wiki/blob/12c55085cced01f2fa8fe34aa322755e4e743c2f/Helper/WikiHelper.php#L41 generates double slashes "funktechno//Wiki" -> bad.

Second and most important: Absolute paths don't work in composer based installations. To fix this, relative paths should be used for including files. The same approach is used in the file /Plugin.php for example.

This pull request fixes this. It works in composer-based and non-composer-based installations.

Note 1: The problematic code was added lateley. There were no warnings in version 0.3.2.

Note 2: There already might be helpers in kanboard to include scripts. If so, they should be used instead.