### PR TITLE
Fix absent 'children' field in public pages

### DIFF
--- a/Template/wiki/detail.php
+++ b/Template/wiki/detail.php
@@ -47,7 +47,7 @@
                 <?php else: ?>
                     <?=$this->url->link(t($page['title']), 'WikiController', 'detail_readonly', array('plugin' => 'wiki', 'token' => $project['token'], 'wiki_id' => $page['id']))?>
                 <?php endif ?>
-                 <?php if (count($page['children']) > 0): ?>
+                 <?php if (isset($page['children']) && count($page['children']) > 0): ?>
                     <?=$this->wikiHelper->renderChildren($page['children'], $page['id'], $project, $not_editable)?>
                 <?php endif ?>
             </li>


### PR DESCRIPTION
### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Description

The array $pages has no 'children' field when rendering puclic pages.

Fixes #101

