### PR TITLE
branching the preview of images attached to a Wiki page due to a change of core API in KB 1.2.38

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 * [ ] Have you updated the ChangeLog with your proposed changes?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
 * pr update to master branch
-  * [ ] Have you updated the getPluginVersion() in Plugin.php and Makefile version appropriately?
+  * [ ] Have you updated the getPluginVersion() in Plugin.php?
 ### New Feature Submissions:
 
 * [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### All Submissions:
 * Notify authors: @lastlink
 * [ ] Have you updated the ChangeLog with your proposed changes?
-* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/funktechno/kanboard-plugin-wiki/pulls) for the same update/change?
 * pr update to master branch
   * [ ] Have you updated the getPluginVersion() in Plugin.php?
 ### New Feature Submissions:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 0.4.1
+* contributors: @imfx77
+
+---
+
+### Bug fixes:
+* Branching the preview of images attached to a Wiki page due to a change of core API in KB v1.2.38
+
 ## Version 0.4.0
 * contributors: @imfx77
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-plugin=Wiki
-version=0.4.0
+extract = $(shell grep -A2 $(1) Plugin.php | tail -n1 | tr -d " ;'" | sed "s/return//")
+
+plugin = $(call extract, getPluginName)
+version = $(call extract, getPluginVersion)
+
 all:
-	@ echo "Build archive for plugin ${plugin} version=${version}"
-	@ git archive HEAD --prefix=${plugin}/ --format=zip -o ${plugin}-${version}.zip
+	@echo "Build archive for plugin ${plugin} version=${version}"
+	@git archive HEAD . :!.github :!.gitignore :!Test :!ChangeLog.md :!README.md :!Makefile --prefix=${plugin}/ --format=zip -9 -o ${plugin}-${version}.zip

--- a/Plugin.php
+++ b/Plugin.php
@@ -100,7 +100,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '0.4.0';
+        return '0.4.1';
     }
 
     public function getPluginHomepage()

--- a/Template/wiki_file/images.php
+++ b/Template/wiki_file/images.php
@@ -2,16 +2,30 @@
     <div class="file-thumbnails">
         <?php foreach ($images as $file): ?>
             <div class="file-thumbnail">
-                <?= $this->app->component('image-slideshow', array(
-                    'images' => $images,
-                    'image' => $file,
-                    'regex' => 'FILE_ID',
-                    'url' => array(
-                        'image'     => $this->url->to('WikiFileViewController', 'image', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
-                        'thumbnail' => $this->url->to('WikiFileViewController', 'thumbnail', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
-                        'download'  => $this->url->to('WikiFileViewController', 'download', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
-                    )
-                )) ?>
+                <?php if (APP_VERSION < '1.2.38'): ?>
+                    <?= $this->app->component('image-slideshow', array(
+                        'images' => $images,
+                        'image' => $file,
+                        'regex' => 'FILE_ID',
+                        'url' => array(
+                            'image'     => $this->url->to('WikiFileViewController', 'image', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
+                            'thumbnail' => $this->url->to('WikiFileViewController', 'thumbnail', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
+                            'download'  => $this->url->to('WikiFileViewController', 'download', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
+                        )
+                    )) ?>
+                <?php else: ?>
+                    <?= $this->app->component('image-slideshow', array(
+                        'images' => $images,
+                        'image' => $file,
+                        'regex_file_id' => 'FILE_ID',
+                        'regex_etag' => 'ETAG',
+                        'url' => array(
+                            'image'     => $this->url->to('WikiFileViewController', 'image', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
+                            'thumbnail' => $this->url->to('WikiFileViewController', 'thumbnail', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
+                            'download'  => $this->url->to('WikiFileViewController', 'download', array('plugin' => 'wiki', 'file_id' => 'FILE_ID')),
+                        )
+                    )) ?>
+                <?php endif ?>
 
                 <div class="file-thumbnail-content">
                     <div class="file-thumbnail-title">
@@ -19,7 +33,7 @@
                             <a href="#" class="dropdown-menu dropdown-menu-link-text" title="<?= $this->text->e($file['name']) ?>"><?= $this->text->e($file['name']) ?> <i class="fa fa-caret-down"></i></a>
                             <ul>
                                 <li>
-                                    <?= $this->url->icon('download', t('Download'), 'WikiFileViewController', 'download', array('plugin' => 'wiki', 'file_id' => $file['id'], 'file_id' => $file['id'])) ?>
+                                    <?= $this->url->icon('download', t('Download'), 'WikiFileViewController', 'download', array('plugin' => 'wiki', 'file_id' => $file['id'])) ?>
                                 </li>
                                 <?php if ($this->user->hasProjectAccess('WikiFileController', 'remove', $wiki['project_id'])): ?>
                                     <li>


### PR DESCRIPTION
### All Submissions:
* Notify authors: @lastlink
* [x] Have you updated the ChangeLog with your proposed changes?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* pr update to master branch
  * [x] Have you updated the getPluginVersion() in Plugin.php and Makefile version appropriately?
### New Feature Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Description

Fixes #108.

Changes proposed in this pull request:

* branching the preview of images attached to a Wiki page due to a change of core API in KB 1.2.38
* automating the makefile to obtain plugin name and version from Plugin.php (no need to manually sync them anymore!!!)
* excluding unnecessary files and folders from the plugin ZIP bundle and setting compression to max level 9
* fixes to the PR template