### PR TITLE
Add wiki:<wiki_id> links in Kanboard

### DIFF
--- a/Asset/css/wiki.css
+++ b/Asset/css/wiki.css
@@ -38,7 +38,7 @@ body.dragging, body.dragging * {
     resize: horizontal;
     overflow: auto;
     max-width: 75% !important;
-    min-width: 384px !important;
+    min-width: 180px !important;
 }
 
 .wikipage {

--- a/Helper/MarkdownHelper.php
+++ b/Helper/MarkdownHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Kanboard\Plugin\Wiki\Helper;
+
+use Kanboard\Helper\TextHelper;
+use ParsedownExtra;
+
+class MarkdownHelper extends TextHelper
+{
+    /**
+     * Markdown transformation
+     *
+     * @param  string    $text
+     * @param  boolean   $isPublicLink
+     * @return string
+     */
+    public function markdown($text, $isPublicLink = false)
+    {
+        $parser = new WikiMarkdown($this->container, $isPublicLink);
+        $parser->setMarkupEscaped(MARKDOWN_ESCAPE_HTML);
+        $parser->setBreaksEnabled(true);
+        $parser->setContainer($this->container);
+
+        return $parser->text($text ?: '');
+    }
+}

--- a/Helper/WikiHelper.php
+++ b/Helper/WikiHelper.php
@@ -5,7 +5,6 @@ namespace Kanboard\Plugin\Wiki\Helper;
 use Kanboard\Core\Base;
 use Kanboard\Model\Wiki;
 
-
 class WikiHelper extends Base
 {
     /**

--- a/Helper/WikiMarkdown.php
+++ b/Helper/WikiMarkdown.php
@@ -25,10 +25,8 @@ class WikiMarkdown extends Markdown
             return $retval;
         }
 
-        echo $href;
         if (!preg_match('!^wiki:(\d+)$!', $href, $matches))
         {
-            echo "Hello";
             return $retval;
         }
 

--- a/Helper/WikiMarkdown.php
+++ b/Helper/WikiMarkdown.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kanboard\Plugin\Wiki\Helper;
+
+use Kanboard\Core\Markdown;
+use Kanboard\Helper\TextHelper;
+use Kanboard\Helper\UrlHelper;
+
+class WikiMarkdown extends Markdown
+{
+    public function setContainer($container)
+    {
+        $this->container = $container;
+    }
+    protected function inlineLink($Excerpt)
+    {
+        $retval = parent::inlineLink($Excerpt);
+        if (!is_array($retval)) {
+            return $retval;
+        }
+
+        $href = $retval['element']['attributes']['href'];
+        if (!is_string($href))
+        {
+            return $retval;
+        }
+
+        echo $href;
+        if (!preg_match('!^wiki:(\d+)$!', $href, $matches))
+        {
+            echo "Hello";
+            return $retval;
+        }
+
+        $wiki_id = $matches[1];
+
+        $href = $this->container['helper']->url->to(
+            'WikiController',
+            'detail',
+            array(
+                'plugin' => 'wiki',
+                'wiki_id' => $wiki_id,
+                'project_id' => $this->container['helper']->url->request->getIntegerParam('project_id')
+            ),
+            'wiki'
+        );
+        $retval['element']['attributes']['href'] = $href;
+        return $retval;
+    }   
+}

--- a/Plugin.php
+++ b/Plugin.php
@@ -63,6 +63,9 @@ class Plugin extends Base
 
         // helpers
         $this->helper->register('wikiHelper', '\Kanboard\Plugin\Wiki\Helper\WikiHelper');
+
+        // Add Markdown extras
+        $this->container['helper']->register('text', '\Kanboard\Plugin\Wiki\Helper\MarkdownHelper');
     }
 
     public function onStartup()

--- a/Template/wiki/detail.php
+++ b/Template/wiki/detail.php
@@ -15,13 +15,11 @@
     'not_editable' => $not_editable,
 )) ?>
 
-<div class="sidebar-content">
+<div class="sidebar-content" style="margin-left: 1em; padding-left: 1em; border-left: 1px solid black">
 <div class="page-header">
-    <h2><?=t($wikipage['title'])?></h2>
     <?php if (!$not_editable): ?>
         <?=$this->modal->medium('edit', t('Edit page'), 'WikiController', 'edit', array('plugin' => 'wiki', 'wiki_id' => $wikipage['id']))?>
         <?=$this->helper->modal->confirm('trash-o', t('Remove page'), 'WikiController', 'confirm', array('plugin' => 'wiki', 'project_id' => $project['id'], 'wiki_id' => $wikipage['id']))?>
-        <button class="separator">&nbsp;&nbsp;&nbsp;&nbsp;</button>
         <?=$this->url->icon('window-restore', t('View Editions'), 'WikiController', 'editions', array('plugin' => 'wiki', 'project_id' => $project['id'], 'wiki_id' => $wikipage['id']))?>
     <?php endif ?>
     <?php if(isset($wikipage['parent_id'])): ?>
@@ -33,6 +31,42 @@
         <?php endif ?>
     <?php endif ?>
 </div>
+
+<div class="wikicontent">
+    <div class="page-header">
+        <h2><?=t($wikipage['title'])?></h2>
+    </div>
+<?php if (!empty($wikipage['content'])): ?>
+    <article class="markdown">
+        <?=$this->text->markdown($wikipage['content'])?>
+    </article>
+<?php endif?>
+
+<?php if (!$not_editable): ?>
+<div class="page-header" style="margin-top: 5em;">
+    <h2><?=t('Attachments')?></h2>
+</div>
+<ul>
+    <?php
+        ini_set('display_errors', 1);
+        ini_set('display_startup_errors', 1);
+        error_reporting(E_ALL);
+    ?>
+    <?=$this->modal->medium('file', t('Attach a document'), 'WikiFileController', 'create', array('plugin' => 'wiki', 'wiki_id' => $wikipage['id'], 'project_id' => $wikipage['project_id']))?>
+    <?= $this->modal->medium('camera', t('Add a screenshot'), 'WikiFileController', 'screenshot', array('plugin' => 'wiki', 'wiki_id' => $wikipage['id'], 'project_id' => $wikipage['project_id'])) ?>
+</ul>
+
+<?php if (!empty($files) || !empty($images)): ?>
+    <?= $this->hook->render('template:task:show:before-attachments', array('wiki' => $wiki, 'project' => $project)) ?>
+    <?= $this->render('wiki:wiki_file/show', array(
+        'wiki' => $wiki,
+        'files' => $files,
+        'images' => $images
+    )) ?>
+<?php endif ?>
+<?php endif ?>
+
+<hr style="margin-top: 2em; margin-bottom: 2em;" />
 
 <div style="float:left">
 <ul class="panel" style="margin:0">
@@ -50,8 +84,6 @@
 </details>
 </ul>
 </div>
-
-<div style="float:left">&nbsp;&nbsp;&nbsp;</div>
 
 <div class="sidebar" style="float:left;max-width:100%;padding:0">
 <ul class="panel" style="margin:0">
@@ -78,40 +110,6 @@
 </ul>
 </div>
 
-<div class="wikicontent">
-<br>
-<?php if (!empty($wikipage['content'])): ?>
-    <div class="page-header">
-        <h2><?=t('Content')?></h2>
-    </div>
-    <article class="markdown">
-        <?=$this->text->markdown($wikipage['content'])?>
-    </article>
-<?php endif?>
-
-<?php if (!$not_editable): ?>
-<div class="page-header">
-        <h2><?=t('Attachments')?></h2>
-</div>
-<ul>
-    <?php
-        ini_set('display_errors', 1);
-        ini_set('display_startup_errors', 1);
-        error_reporting(E_ALL);
-    ?>
-    <?=$this->modal->medium('file', t('Attach a document'), 'WikiFileController', 'create', array('plugin' => 'wiki', 'wiki_id' => $wikipage['id'], 'project_id' => $wikipage['project_id']))?>
-    <?= $this->modal->medium('camera', t('Add a screenshot'), 'WikiFileController', 'screenshot', array('plugin' => 'wiki', 'wiki_id' => $wikipage['id'], 'project_id' => $wikipage['project_id'])) ?>
-</ul>
-
-<?php if (!empty($files) || !empty($images)): ?>
-    <?= $this->hook->render('template:task:show:before-attachments', array('wiki' => $wiki, 'project' => $project)) ?>
-    <?= $this->render('wiki:wiki_file/show', array(
-        'wiki' => $wiki,
-        'files' => $files,
-        'images' => $images
-    )) ?>
-<?php endif ?>
-<?php endif ?>
 
 </div>
 

--- a/Template/wiki/sidebar.php
+++ b/Template/wiki/sidebar.php
@@ -26,9 +26,9 @@ $is_active = ($wiki_id == 0) ? ' active' : '';
     <br>
     <h2><?= t('Wiki') ?> <?= t('Content') ?></h2>
     <div style="float: right">
-        <button class="gotoSelected actionBigger" title="<?= t('Go to Selected Wiki Page') ?>"><a><i class="fa fa-share-square"></i></a></button>
-        <button class="expandAll actionBigger"title="<?= t('Expand All Wiki Subpages') ?>"><a><i class="fa fa-plus-square"></i></a></button>
-        <button class="collapseAll actionBigger"title="<?= t('Collapse All Wiki Subpages') ?>"><a><i class="fa fa-minus-square"></i></a></button>
+        <button class="gotoSelected" title="<?= t('Go to Selected Wiki Page') ?>"><a><i class="fa fa-share-square"></i></a></button>
+        <button class="expandAll"title="<?= t('Expand All Wiki Subpages') ?>"><a><i class="fa fa-plus-square"></i></a></button>
+        <button class="collapseAll"title="<?= t('Collapse All Wiki Subpages') ?>"><a><i class="fa fa-minus-square"></i></a></button>
     </div>
 </div>
 <br>
@@ -36,7 +36,7 @@ $is_active = ($wiki_id == 0) ? ' active' : '';
 <?php if (!empty($wikipages)): ?>
     <ul id="wikitree" data-selected-wiki-id="<?=$wiki_id?>" <?php if (!$not_editable): ?>data-reorder-url="<?= $this->url->href('WikiAjaxController', 'reorder_by_index', array('plugin' => 'wiki', 'project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>"<?php endif ?>>
     <li class="wikipage<?=$is_active?>" data-project-id="<?= $project['id'] ?>" data-page-id="0" data-page-order="0">
-    <button class="branch actionBigger" title="' . t('Expand/Collapse Subpages') . '"><a><i class="fa fa-minus-square-o"></i></a></button>
+    <button class="branch" title="' . t('Expand/Collapse Subpages') . '"><a><i class="fa fa-minus-square-o"></i></a></button>
     <?php if (!$not_editable): ?>
         <?=$this->helper->url->icon('home', t('(root)'), 'WikiController', 'detail', array('plugin' => 'wiki', 'project_id' => $project['id'], 'wiki_id' => 0), false, 'wikilink'.$is_active)?>
     <?php else: ?>


### PR DESCRIPTION
This **quick and dirty hack** attempts to add `wiki:<wiki_id>` links to Kanboard.  This would be an awesome feature.  Can you contribute?

### All Submissions:
* Notify authors: @lastlink
* [ ] Have you updated the ChangeLog with your proposed changes?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/funktechno/kanboard-plugin-wiki/pulls) for the same update/change?
* pr update to master branch
  * [ ] Have you updated the getPluginVersion() in Plugin.php?
### New Feature Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

### Description

Fixes # .

Changes proposed in this pull request:

* Add the ability to use `[My Title](wiki:<wiki_id>)` links that translate to a Kanboard URL.
* If we could use these links in tasks that would be great.
* If we could get that "popup" that kanboard shows when typing `#99` I would simply pass out.
